### PR TITLE
Added loader support for the Twig Assets extension . This means that it is now possible to use twig paths in the definition

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+* text=auto eol=lf
+
 .* export-ignore
 infection/ export-ignore
 phpunit.xml.dist export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /vendor/
 /phpunit.xml
 /composer.lock
+/.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -193,6 +193,20 @@ $twig->addExtension(new \Enjoys\AssetsCollector\Extensions\Twig\AssetsExtension(
  {{  asset('js', ['path/script.js', 'script.js'], 'namespace') }}
 ```
 
+**С версии 2.2.1 поддерживаются пути twig**
+
+Необходимо при инициализации расширения передать загрузчик, который реализует `\Twig\Loader\LoaderInterface`,
+например `\Twig\Loader\FilesystemLoader`
+
+```php
+/** 
+ * @var \Enjoys\AssetsCollector\Extensions\Twig\AssetsExtension $extension 
+ * @var \Enjoys\AssetsCollector\Assets $assets
+ * @var \Twig\Loader\LoaderInterface $loader
+ */
+$extension = new AssetsExtension($assets, $loader));
+```
+
 **Вывод в шаблоне**
 
 ```twig
@@ -206,7 +220,6 @@ $twig->addExtension(new \Enjoys\AssetsCollector\Extensions\Twig\AssetsExtension(
 
 По умолчанию в качестве минификатора используется **NullMinify::class**, то есть ничего не сжимается. Для установки
 минификатора, в Environment используется метод **Environment::setMinifyCSS(MinifyInterface $minifyImpl)**
-
 
 Базовая реализация CSS Minify реализована с помощью библиотеки **tubalmartin\CssMin**
 Подробное описание параметров: https://github.com/tubalmartin/YUI-CSS-compressor-PHP-port#api
@@ -242,7 +255,7 @@ $environment->setMinifyCSS(
 Базовая реализация CSS Minify реализована с помощью библиотеки **JShrink**
 Подробнее про [JShrink](https://github.com/tedious/JShrink)
 
-Легко можно реализовать минификацию с помощью других библиотек, реализовав интерфейс 
+Легко можно реализовать минификацию с помощью других библиотек, реализовав интерфейс
 *\Enjoys\AssetsCollector\Content\Minify\MinifyInterface::class*
 
 ```php

--- a/tests/Extensions/Twig/AssetsExtensionTest.php
+++ b/tests/Extensions/Twig/AssetsExtensionTest.php
@@ -6,6 +6,7 @@ use Enjoys\AssetsCollector\Assets;
 use Enjoys\AssetsCollector\Environment;
 use Enjoys\AssetsCollector\Extensions\Twig\AssetsExtension;
 use PHPUnit\Framework\TestCase;
+use Twig\Loader\FilesystemLoader;
 
 class AssetsExtensionTest extends TestCase
 {
@@ -17,6 +18,7 @@ class AssetsExtensionTest extends TestCase
      * @var AssetsExtension
      */
     private AssetsExtension $extension;
+
 
     protected function setUp(): void
     {
@@ -46,7 +48,6 @@ class AssetsExtensionTest extends TestCase
     }
 
 
-
     public function testGetExternJs()
     {
         $this->assertSame(
@@ -60,6 +61,36 @@ class AssetsExtensionTest extends TestCase
         $this->assertSame(
             "<link type='text/css' rel='stylesheet' href='http://google.com' />\n<link type='text/css' rel='stylesheet' href='http://yandex.ru' />\n",
             $this->extension->getExternCss()
+        );
+    }
+
+    public function dataForTestExtensionWithTwigLoader()
+    {
+        return [
+            [
+                new FilesystemLoader('/', __DIR__ . '/../../fixtures/twig_root_path'),
+                "<link type='text/css' rel='stylesheet' href='/fixtures/twig_root_path/test.css' />\n<link type='text/css' rel='stylesheet' href='/fixtures/test.css' />\n"
+            ],
+            [null, "<link type='text/css' rel='stylesheet' href='/fixtures/test.css' />\n"]
+        ];
+    }
+
+    /**
+     * @dataProvider dataForTestExtensionWithTwigLoader
+     */
+    public function testExtensionWithTwigLoader($loader, $expect)
+    {
+        $environment = new Environment('_compile', __DIR__ . '/../..');
+        $assetsCollector = new Assets($environment);
+        $extension = new AssetsExtension($assetsCollector, $loader);
+
+        $extension->asset('css', [
+            'test.css',
+            'tests/fixtures/test.css'
+        ]);
+        $this->assertSame(
+            $expect,
+            $extension->getExternCss()
         );
     }
 }

--- a/tests/fixtures/twig_root_path/test.css
+++ b/tests/fixtures/twig_root_path/test.css
@@ -1,0 +1,3 @@
+.twig_loader {
+
+}


### PR DESCRIPTION
```php
/** 
 * @var \Enjoys\AssetsCollector\Extensions\Twig\AssetsExtension $extension 
 * @var \Enjoys\AssetsCollector\Assets $assets
 * @var \Twig\Loader\LoaderInterface $loader
 */
$extension = new AssetsExtension($assets, $loader));
```